### PR TITLE
Add fuzz harness rename and update targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [format-check, checkstyle-check, unit-tests, integration-tests, property-tests, mock-tests, mutation-tests]
+    needs: [format-check, checkstyle-check, unit-tests, integration-tests, property-tests, mock-tests, mutation-tests, test-fuzz]
 
     steps:
       - name: Checkout code
@@ -211,5 +211,26 @@ jobs:
 
       - name: Run mock tests
         run: make test-mock
+        env:
+          CI: true
+
+  test-fuzz:
+    name: Fuzz Time Tools
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Run TimeService fuzzing
+        run: make test-fuzz
         env:
           CI: true

--- a/Makefile
+++ b/Makefile
@@ -171,10 +171,15 @@ test-mutation-incremental: ## Run incremental PITest mutation testing
 test-mutation-memory-only: clean ## Run mutation testing only on MemoryService
 	@echo "Running mutation testing on MemoryService only..."
 	@$(MVN) org.pitest:pitest-maven:mutationCoverage \
-		-DtargetClasses=com.jasonriddle.mcp.memory.MemoryService \
-		-DtargetTests=com.jasonriddle.mcp.memory.*PITMutationTest \
-		-q --no-transfer-progress
+	 -DtargetClasses=com.jasonriddle.mcp.memory.MemoryService \
+	 -DtargetTests=com.jasonriddle.mcp.memory.*PITMutationTest \
+	 -q --no-transfer-progress
 	@echo "✓ MemoryService mutation testing complete"
+
+test-fuzz: clean ## Run Jazzer fuzzing on TimeService
+	@echo "Running Jazzer fuzzing on TimeService..."
+	@$(MVN) test -Dtest=com.jasonriddle.mcp.time.TimeServiceFuzzTest -P fuzz-time -q --no-transfer-progress
+	@echo "✓ TimeService fuzzing complete"
 
 # test-stdio: clean ## Run STDIO integration tests only
 # 	@echo "Running STDIO integration tests..."

--- a/README.md
+++ b/README.md
@@ -578,6 +578,7 @@ make checkstyle             # Run style checks
 # Testing
 make test                   # Run unit tests
 make test-integration       # Run integration tests
+make test-fuzz            # Fuzz TimeService with Jazzer
 
 
 # Cleanup
@@ -601,6 +602,7 @@ make test
 
 # Run integration tests only
 make test-integration
+make test-fuzz
 
 # Run specific test class
 ./mvnw test -Dtest=MemoryServiceTest

--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,19 @@
             <version>0.5.3</version>
             <scope>test</scope>
         </dependency>
+        <!-- Jazzer for fuzz testing -->
+        <dependency>
+            <groupId>com.code-intelligence</groupId>
+            <artifactId>jazzer-junit</artifactId>
+            <version>0.24.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.code-intelligence</groupId>
+            <artifactId>jazzer-api</artifactId>
+            <version>0.24.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <!-- Build Configuration -->
@@ -383,6 +396,8 @@
                         <exclude>**/*MockTest.java</exclude>
                         <!-- Mutation Tests -->
                         <exclude>**/*PITMutationTest.java</exclude>
+                        <!-- Fuzz Tests -->
+                        <exclude>**/*FuzzTest.java</exclude>
                     </excludes>
                     <systemPropertyVariables>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
@@ -619,6 +634,22 @@
                                 <phase>test</phase>
                             </execution>
                         </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <!-- Fuzzing Profile for TimeService -->
+        <profile>
+            <id>fuzz-time</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.code-intelligence</groupId>
+                        <artifactId>jazzer-maven-plugin</artifactId>
+                        <version>0.24.0</version>
+                        <configuration>
+                            <includes>com.jasonriddle.mcp.time.TimeServiceFuzzTest</includes>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/src/test/java/com/jasonriddle/mcp/time/TimeServiceFuzzTest.java
+++ b/src/test/java/com/jasonriddle/mcp/time/TimeServiceFuzzTest.java
@@ -1,0 +1,63 @@
+package com.jasonriddle.mcp.time;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import com.code_intelligence.jazzer.junit.FuzzTest;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+/**
+ * Jazzer fuzzing harness for {@link TimeService}.
+ */
+final class TimeServiceFuzzTest {
+
+    private final TimeService timeService = new TimeService();
+
+    /**
+     * Fuzz the {@link TimeService#getCurrentTime(String)} method.
+     *
+     * @param data supplied fuzzing data
+     */
+    @FuzzTest
+    void fuzzGetCurrentTime(final FuzzedDataProvider data) {
+        final String timezone = data.consumeString(50);
+        try {
+            timeService.getCurrentTime(timezone);
+        } catch (IllegalArgumentException ignored) {
+            // Expected for invalid timezones
+        }
+    }
+
+    /**
+     * Fuzz the {@link TimeService#convertTime(String, String, String)} method.
+     *
+     * @param data supplied fuzzing data
+     */
+    @FuzzTest
+    void fuzzConvertTime(final FuzzedDataProvider data) {
+        final String source = data.consumeString(50);
+        final String time = data.consumeString(8);
+        final String target = data.consumeRemainingAsString();
+        try {
+            timeService.convertTime(source, time, target);
+        } catch (IllegalArgumentException ignored) {
+            // Expected for invalid inputs
+        }
+    }
+
+    /**
+     * Fuzz the {@link TimeService#isDaylightSavingTime(ZonedDateTime)} method.
+     *
+     * @param data supplied fuzzing data
+     */
+    @FuzzTest
+    void fuzzIsDst(final FuzzedDataProvider data) {
+        final String zoneName = data.consumeString(50);
+        try {
+            final ZoneId zone = ZoneId.of(zoneName);
+            final ZonedDateTime time = ZonedDateTime.now(zone);
+            timeService.isDaylightSavingTime(time);
+        } catch (Exception ignored) {
+            // Ignore invalid zones
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Rename `TimeServiceFuzzer` to `TimeServiceFuzzTest`
- Replace `fuzz-time` target with `test-fuzz`
- Exclude fuzz tests from default test runs
- Update CI and README for the new fuzzing target

## Testing
- `make format` *(fails: Could not resolve Maven dependencies)*
- `make checkstyle` *(fails: Could not resolve Maven dependencies)*
- `make test` *(fails: Could not resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68701268441c832894086a3a08d23234