### PR TITLE
Inject Clock into TimeService for deterministic tests

### DIFF
--- a/src/main/java/com/jasonriddle/mcp/time/TimeService.java
+++ b/src/main/java/com/jasonriddle/mcp/time/TimeService.java
@@ -1,6 +1,8 @@
 package com.jasonriddle.mcp.time;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZoneId;
@@ -17,6 +19,25 @@ public final class TimeService {
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
     private static final long SECONDS_PER_HOUR = 3600L;
 
+    private final Clock clock;
+
+    /**
+     * Create a new TimeService using the provided clock.
+     *
+     * @param clock clock instance used for time calculations.
+     */
+    @Inject
+    public TimeService(final Clock clock) {
+        this.clock = clock;
+    }
+
+    /**
+     * Create a new TimeService using the system default clock.
+     */
+    public TimeService() {
+        this(Clock.systemDefaultZone());
+    }
+
     /**
      * Get current time in specified timezone.
      *
@@ -27,7 +48,7 @@ public final class TimeService {
     public ZonedDateTime getCurrentTime(final String timezoneName) {
         try {
             final ZoneId timezone = ZoneId.of(timezoneName);
-            return ZonedDateTime.now(timezone);
+            return ZonedDateTime.now(clock.withZone(timezone));
         } catch (Exception e) {
             throw new IllegalArgumentException("Invalid timezone: " + timezoneName, e);
         }
@@ -49,7 +70,7 @@ public final class TimeService {
         final ZoneId targetZone = parseTimezone(targetTimezone);
         final LocalTime parsedTime = parseTimeString(timeString);
 
-        final LocalDate currentDate = LocalDate.now();
+        final LocalDate currentDate = LocalDate.now(clock);
         final ZonedDateTime sourceTime = ZonedDateTime.of(currentDate, parsedTime, sourceZone);
         final ZonedDateTime targetTime = sourceTime.withZoneSameInstant(targetZone);
 

--- a/src/test/java/com/jasonriddle/mcp/McpTimeToolsUnitTest.java
+++ b/src/test/java/com/jasonriddle/mcp/McpTimeToolsUnitTest.java
@@ -6,6 +6,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.jasonriddle.mcp.time.TimeService;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Map;
@@ -22,7 +25,11 @@ final class McpTimeToolsUnitTest {
 
     @BeforeEach
     void setUp() {
-        timeService = new TimeService();
+        final Clock fixedClock =
+                Clock.fixed(
+                        Instant.parse("2024-01-01T12:00:00Z"),
+                        ZoneId.of("UTC"));
+        timeService = new TimeService(fixedClock);
         mcpTimeTools = new McpTimeTools();
         mcpTimeTools.timeService = timeService;
     }

--- a/src/test/java/com/jasonriddle/mcp/time/TimeServiceUnitTest.java
+++ b/src/test/java/com/jasonriddle/mcp/time/TimeServiceUnitTest.java
@@ -7,6 +7,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.test.junit.QuarkusTest;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -18,10 +22,15 @@ import org.junit.jupiter.api.Test;
 class TimeServiceUnitTest {
 
     private TimeService timeService;
+    private Clock fixedClock;
 
     @BeforeEach
     void setUp() {
-        timeService = new TimeService();
+        fixedClock =
+                Clock.fixed(
+                        Instant.parse("2024-01-01T12:00:00Z"),
+                        ZoneId.of("UTC"));
+        timeService = new TimeService(fixedClock);
     }
 
     @Test
@@ -42,14 +51,9 @@ class TimeServiceUnitTest {
         assertEquals("Asia/Tokyo", tokyoTime.getZone().getId());
         assertEquals("Europe/London", londonTime.getZone().getId());
 
-        // All should be approximately the same instant
-        final long utcSeconds = utcTime.toEpochSecond();
-        final long tokyoSeconds = tokyoTime.toEpochSecond();
-        final long londonSeconds = londonTime.toEpochSecond();
-
-        // Should be within 1 second of each other (accounting for test execution time)
-        assertTrue(Math.abs(utcSeconds - tokyoSeconds) <= 1);
-        assertTrue(Math.abs(utcSeconds - londonSeconds) <= 1);
+        // All should represent the same instant
+        assertEquals(utcTime.toInstant(), tokyoTime.toInstant());
+        assertEquals(utcTime.toInstant(), londonTime.toInstant());
     }
 
     @Test
@@ -250,5 +254,40 @@ class TimeServiceUnitTest {
         // Both should be valid boolean values (not null)
         assertNotNull(currentDst);
         assertNotNull(conversionDst);
+    }
+
+    @Test
+    void testGetCurrentTimeFixedClock() {
+        final ZonedDateTime nyTime = timeService.getCurrentTime("America/New_York");
+
+        assertEquals(7, nyTime.getHour());
+        assertEquals(0, nyTime.getMinute());
+        assertEquals("America/New_York", nyTime.getZone().getId());
+    }
+
+    @Test
+    void testConvertTimeAcrossDateBoundary() {
+        final Clock eveningClock =
+                Clock.fixed(Instant.parse("2024-01-01T23:30:00Z"), ZoneId.of("UTC"));
+        final TimeService eveningService = new TimeService(eveningClock);
+
+        final TimeConversionResult result = eveningService.convertTime("UTC", "23:30", "Asia/Tokyo");
+
+        assertEquals(23, result.sourceTime().getHour());
+        assertEquals(30, result.sourceTime().getMinute());
+        assertEquals(8, result.targetTime().getHour());
+        assertEquals(30, result.targetTime().getMinute());
+        assertEquals(2, result.targetTime().getDayOfMonth());
+    }
+
+    @Test
+    void testIsDaylightSavingTimeSpecificDates() {
+        final ZonedDateTime summer =
+                ZonedDateTime.of(LocalDateTime.of(2024, 7, 1, 12, 0), ZoneId.of("America/New_York"));
+        final ZonedDateTime winter =
+                ZonedDateTime.of(LocalDateTime.of(2024, 1, 1, 12, 0), ZoneId.of("America/New_York"));
+
+        assertTrue(timeService.isDaylightSavingTime(summer));
+        assertFalse(timeService.isDaylightSavingTime(winter));
     }
 }


### PR DESCRIPTION
## Summary
- Allow injecting a Clock into `TimeService`
- Update tests to use a fixed clock
- Add new unit tests for fixed time scenarios

## Testing
- `make format` *(fails: Could not resolve Maven dependencies)*
- `make checkstyle` *(fails: Could not resolve Maven dependencies)*
- `make test` *(fails: Could not resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68709c91840483289b1152e10e3c58ef